### PR TITLE
Fix/translation widget overlap

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -14,7 +14,7 @@ header {
     }
   
     &__lc-button {
-      @apply text-secondary justify-self-end xl:col-start-7;
+      @apply text-secondary xl:col-start-7;
     }
   }
 }


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

~~Small fix for the overlap on the translation widget in the header ~~

#### Testing
*go to the Home Page, participate.nyc.gov. Change viewport size to mobile. Observe that the translation widget no longer overlaps with the hamburger menu*

Example:
* Log in as admin
* Access Backoffice
* Go to organization settings
* See ...

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #?

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

#### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*

#### Extra information